### PR TITLE
Extra logging, reworked user_data

### DIFF
--- a/examples/spi_master/pytest.ini
+++ b/examples/spi_master/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_file = pytest.log
+log_file_level = DEBUG
+log_file_format = [%(levelname)s][%(module)s] %(asctime)s - %(message)s
+log_file_date_format = %Y-%m-%d %H:%M:%S

--- a/python/test/test_verisocks.py
+++ b/python/test/test_verisocks.py
@@ -41,7 +41,10 @@ def vs():
     _vs.connect()
     yield _vs
     # Teardown
-    _vs.finish()
+    try:
+        _vs.finish()
+    except ConnectionError:
+        logging.warning("Connection error - Cannot send finish command")
     _vs.close()
     pop.communicate(timeout=10)
 
@@ -307,6 +310,11 @@ def test_set(vs):
 def test_read_not_expected(vs):
     # No data expected
     assert vs.read() is False
+
+
+def test_sim_finishes(vs):
+    with pytest.raises(VerisocksError):
+        answer = vs.run(cb="until_time", time=1200, time_unit="us")
 
 
 def test_context_manager():

--- a/python/verisocks/verisocks.py
+++ b/python/verisocks/verisocks.py
@@ -311,17 +311,18 @@ Use queue_message().")
         Returns:
             (JSON object): Content of returned message.
         """
+
+        if "timeout" in cmd:
+            timeout = cmd.pop("timeout")
+        else:
+            timeout = None
+
         self.queue_message({
             "type": "application/json",
             "encoding": "utf-8",
             "content": cmd
         })
         self.write()
-
-        if "timeout" in cmd:
-            timeout = cmd.pop("timeout")
-        else:
-            timeout = None
 
         if (self.read(10, timeout)):
             if self.rx_content["type"] == "error":
@@ -411,21 +412,21 @@ Use queue_message().")
         """
         return self.send(command="get", sel=sel, **kwargs)
 
-    def finish(self):
+    def finish(self, timeout=None):
         """Sends a "finish" command to the Verisocks server that terminates
         the simulation (and therefore also closes the Verisocks server itself).
         The connection is closed as well by the function as a clean-up.
         """
-        retval = self.send(command="finish")
+        retval = self.send(command="finish", timeout=timeout)
         self.close()
         return retval
 
-    def stop(self):
+    def stop(self, timeout=None):
         """Sends a "stop" command to the Verisocks server that stops
         the simulation. The Verisocks server socket is not closed, but the
         simulation has to be restarted for any new request to be processed.
         """
-        return self.send(command="stop")
+        return self.send(command="stop", timeout=timeout)
 
     def exit(self):
         """Sends an "exit" command to the Verisocks server that gives back


### PR DESCRIPTION
- [Python client] Added timeout as argument for "finish" command
- [Python client] Suppressed unnecessary timeout from kw args in low-level function 
- Improved logging with a few extra messages for easier debug
- Changed callbacks store user data from systf to vs_vpi_data_t struct to be more efficient