### PR TITLE
Changes for release 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ tags
 Makefile
 include/vpi_config.h
 *.fst
+obj_dir/
+cvcsim
 
 # autoconf files
 config.status

--- a/Makefile.in
+++ b/Makefile.in
@@ -7,6 +7,7 @@ BUILDDIR = build
 INCDIRS += $(SRCDIR)/include
 INCDIRS += $(SRCDIR)/cjson
 LIBVPI = $(BUILDDIR)/verisocks.vpi
+DOCSDIR = docs
 
 CC = @CC@
 CFLAGS = @CFLAGS@
@@ -45,7 +46,10 @@ $(BUILDDIR)/%.o: %.c
 	@mkdir -p $(BUILDDIR)
 	$(CC) -o $@ -c $(CFLAGS) $<
 
-.PHONY: clean all
+.PHONY: clean all docs
+
+docs:
+	$(MAKE) -C $(DOCSDIR) html
 
 clean:
 	-$(RM) $(OBJS)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,8 +9,8 @@
 project = 'Verisocks'
 copyright = '2023, Jérémie Chabloz'
 author = 'Jérémie Chabloz'
-version = '1.1.0'
-release = '1.1.0'
+version = '1.1.1-dev'
+release = '1.1.1'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,8 +9,8 @@
 project = 'Verisocks'
 copyright = '2023, Jérémie Chabloz'
 author = 'Jérémie Chabloz'
-version = '1.1.1-dev'
-release = '1.1.1'
+version = '1.2.0-dev'
+release = '1.2.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = 'Verisocks'
 copyright = '2023, Jérémie Chabloz'
 author = 'Jérémie Chabloz'
-version = '1.2.0-dev'
+version = '1.2.0'
 release = '1.2.0'
 
 # -- General configuration ---------------------------------------------------

--- a/docs/src/intro.rst
+++ b/docs/src/intro.rst
@@ -21,7 +21,7 @@ to trying and compile Verisocks:
   packaged version provided with your favorite distro.
 * GCC C or C++ compiler
 
-.. note:: 
+.. note::
 
     Older GCC versions will most likely complain about the variadic macros used
     for logging purposes. These warnings can normally be safely ignored...
@@ -68,6 +68,11 @@ not to impact your system's Python packages.
 
     pip install <path to your verisocks folder>/python
 
+.. note::
+
+  The main advantage of Verisock's socket interface is its versatility. The
+  Python client provided with the code can serve as a reference implementation
+  that can easily be replicated in any language with an API for TCP sockets.
 
 Run the examples
 ----------------
@@ -138,12 +143,23 @@ have to typically be:
   variable rising edge),
 * etc...
 
+.. _sec_alternative_simulators:
+
+Alternative simulators
+**********************
+
+While the Verisocks PLI application has been developed targeting specifically
+Icarus as a verilog simulator, there is no known reason that it would not be
+working as well with any other simulator that is supporting the VPI normative
+interface (as defined in `IEEE Std 1364
+<https://ieeexplore.ieee.org/document/1620780>`_ and `IEEE Std 1800
+<https://ieeexplore.ieee.org/document/10458102>`_), including mainstream
+commercial simulators.
+
 .. note::
-
-    Note that while the Verisocks PLI application has been developed targeting
-    specifically Icarus as a verilog simulator, there is no known reason that
-    it would not be working as well with any other simulator that is supporting
-    the VPI interface standard, including mainstream commercial simulators. I
-    will gladly accept any contribution that may confirm or infirm this
-    statement...
-
+    I will gladly accept any contribution to test Verisocks with other
+    simulators.
+    As of now, I have only successfully tested it with Cadence's XCelium 64
+    29.03. As soon as I get more material, I will make a short tutorial for it.
+    My next target will be Tachyon's CVC. If anybody is able to test it with
+    QuestaSim...

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -8,7 +8,7 @@ Releases of documentation and code are using the same version numbers. The
 version numbering system follows the `semantic versioning
 <https://semver.org/>`_ principles.
 
-1.1.1 - Ongoing
+1.2.0 - Ongoing
 ***************
 
 * Modified :py:class:`Verisocks<verisocks.verisocks.Verisocks>` constructor and

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -11,11 +11,15 @@ version numbering system follows the `semantic versioning
 1.1.1 - Ongoing
 ***************
 
-* Modified :py:meth:`Verisocks.connect()
-  <verisocks.verisocks.Verisocks.connect>` method to include multiple, delayed
-  connection trials. Examples and test have been simplified accordingly.
+* Modified :py:class:`Verisocks<verisocks.verisocks.Verisocks>` constructor and
+  :py:meth:`Verisocks.connect() <verisocks.verisocks.Verisocks.connect>` method
+  to include arguments for multiple, delayed connection trials. Examples and
+  test have been simplified accordingly.
 * Added correct management of system call interrupts while waiting on client
-  connection in the server code.
+  connection in the server code (see
+  https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html
+  for details).
+* Added section :ref:`sec_alternative_simulators`.
 
 1.1.0 - 2024-02-07
 ******************

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -8,8 +8,8 @@ Releases of documentation and code are using the same version numbers. The
 version numbering system follows the `semantic versioning
 <https://semver.org/>`_ principles.
 
-1.2.0 - Ongoing
-***************
+1.2.0 - 2024-03-16
+******************
 
 * Modified :py:class:`Verisocks<verisocks.verisocks.Verisocks>` constructor and
   :py:meth:`Verisocks.connect() <verisocks.verisocks.Verisocks.connect>` method

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -8,6 +8,14 @@ Releases of documentation and code are using the same version numbers. The
 version numbering system follows the `semantic versioning
 <https://semver.org/>`_ principles.
 
+1.1.1 - Ongoing
+***************
+
+* Modified :py:meth:`Verisocks.connect()
+  <verisocks.verisocks.Verisocks.connect>` method to include multiple, delayed
+  connection trials. Examples and test have been simplified accordingly.
+* Added correct management of system call interrupts while waiting on client
+  connection in the server code.
 
 1.1.0 - 2024-02-07
 ******************

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -20,6 +20,8 @@ version numbering system follows the `semantic versioning
   https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html
   for details).
 * Added section :ref:`sec_alternative_simulators`.
+* Added method :py:meth:`verisocks.utils.setup_sim_run` to simplify foreseen
+  support for alternative simulators.
 
 1.1.0 - 2024-02-07
 ******************

--- a/examples/hello_world/test_hello_world.py
+++ b/examples/hello_world/test_hello_world.py
@@ -1,7 +1,6 @@
 from verisocks.verisocks import Verisocks
 from verisocks.utils import setup_sim, find_free_port
 import socket
-import time
 import pytest
 import logging
 import os.path
@@ -11,7 +10,6 @@ HOST = socket.gethostbyname("localhost")
 PORT = find_free_port()
 VS_TIMEOUT = 10
 LIBVPI = "../../build/verisocks.vpi"
-CONNECT_DELAY = 0.1
 
 
 def setup_test():
@@ -24,7 +22,6 @@ def setup_test():
             f"-DVS_TIMEOUT={VS_TIMEOUT}"
         ]
     )
-    time.sleep(CONNECT_DELAY)
 
 
 @pytest.fixture

--- a/examples/spi_master/test_spi_master.py
+++ b/examples/spi_master/test_spi_master.py
@@ -1,7 +1,6 @@
 from verisocks.verisocks import Verisocks
 from verisocks.utils import setup_sim, find_free_port
 import os.path
-import time
 import logging
 import pytest
 import socket
@@ -12,7 +11,6 @@ import random
 HOST = socket.gethostbyname("localhost")
 PORT = find_free_port()
 LIBVPI = "../../build/verisocks.vpi"  # Relative path to this file!
-CONNECT_DELAY = 0.01
 VS_TIMEOUT = 10
 SRC = ["spi_master.v", "spi_slave.v", "spi_master_tb.v"]
 
@@ -29,7 +27,6 @@ def setup_test():
             "-DDUMP_FILE=\"spi_master_tb.fst\""
         ]
     )
-    time.sleep(CONNECT_DELAY)
 
 
 def send_spi(vs, tx_buffer):

--- a/python/test/test_verisocks.py
+++ b/python/test/test_verisocks.py
@@ -1,7 +1,6 @@
 from verisocks.verisocks import Verisocks, VerisocksError
 import subprocess
 import os.path
-import time
 import shutil
 import pytest
 import logging
@@ -17,7 +16,6 @@ import socket
 # Parameters
 HOST = socket.gethostbyname("localhost")
 LIBVPI = "../../build/verisocks.vpi"  # Relative path to this file!
-CONNECT_DELAY = 0.1
 VS_TIMEOUT = 2
 
 
@@ -81,10 +79,6 @@ def setup_iverilog(port, src_file):
     pop = subprocess.Popen(
         cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     print(f"Launched Icarus with PID {pop.pid}")
-    # Some delay is required for Icarus to launch the Verisocks server before
-    # being able to connect - Please adjust CONNECT_DELAY if required.
-
-    time.sleep(CONNECT_DELAY)
     return pop
 
 
@@ -105,9 +99,9 @@ def test_already_connected(vs, caplog):
 def test_connect_error():
     """Tests trying to connect to a non-running server"""
     port = find_free_port()
-    with pytest.raises(ConnectionRefusedError):
+    with pytest.raises(ConnectionError):
         vs = Verisocks(HOST, port)
-        vs.connect()
+        vs.connect(trials=1)
     vs.close()
 
 

--- a/python/verisocks/__init__.py
+++ b/python/verisocks/__init__.py
@@ -1,4 +1,4 @@
 """Verisocks Python client API
 """
 
-__version__ = "1.2.0-dev"
+__version__ = "1.2.0"

--- a/python/verisocks/__init__.py
+++ b/python/verisocks/__init__.py
@@ -1,4 +1,4 @@
 """Verisocks Python client API
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1-dev"

--- a/python/verisocks/__init__.py
+++ b/python/verisocks/__init__.py
@@ -1,4 +1,4 @@
 """Verisocks Python client API
 """
 
-__version__ = "1.1.1-dev"
+__version__ = "1.2.0-dev"

--- a/python/verisocks/utils.py
+++ b/python/verisocks/utils.py
@@ -29,7 +29,7 @@ def _format_path(cwd, path):
     return os.path.abspath(os.path.join(cwd, path))
 
 
-def run_setup_cmds(elab_cmd, sim_cmd, capture_output=True):
+def setup_sim_run(elab_cmd, sim_cmd, capture_output=True):
     """Run simulation setup commands.
 
     This command is e.g. used by :py:meth:`setup_sim` with elaboration and
@@ -73,7 +73,8 @@ def setup_sim(vpi_libpath, *src_files, cwd=".", vvp_filepath=None,
               vvp_exec=None, vvp_args=None, vvp_postargs=None,
               capture_output=True):
     """Set up Icarus simulation by elaborating the design with :code:`iverilog`
-    and launching the simulation with :code:`vvp`.
+    and launching the simulation with :code:`vvp`. Uses
+    :py:meth:`setup_sim_run` to run the concatenated commands and arguments.
 
     Args:
         vpi_libpath (str): Path to the compiled Verisocks VPI library.
@@ -159,5 +160,5 @@ def setup_sim(vpi_libpath, *src_files, cwd=".", vvp_filepath=None,
         *vvp_postargs
     ]
 
-    pop = run_setup_cmds(ivl_cmd, vvp_cmd, capture_output)
+    pop = setup_sim_run(ivl_cmd, vvp_cmd, capture_output)
     return pop

--- a/python/verisocks/utils.py
+++ b/python/verisocks/utils.py
@@ -30,8 +30,18 @@ def _format_path(cwd, path):
 
 
 def run_setup_cmds(elab_cmd, sim_cmd, capture_output=True):
-    """
+    """Run simulation setup commands.
+
+    This command is e.g. used by :py:meth:`setup_sim` with elaboration and
+    simulation commands formatted according to the provided arguments.
+
     Args:
+        elab_cmd (list): Elaboration command. It has to be provided as a list
+            of command and arguments (see subprocess documentation). If None,
+            this step is skipped.
+        sim_cmd (list): Simulation command. It has to be provided as a list
+            of command and arguments (see subprocess documentation). This
+            command is mandatory and cannot be None.
         capture_output (bool): Defines if stdout and stderr output
             are "captured" (i.e. not visible).
 
@@ -41,6 +51,9 @@ def run_setup_cmds(elab_cmd, sim_cmd, capture_output=True):
 
     if elab_cmd:
         subprocess.check_call(elab_cmd)
+
+    if sim_cmd is None:
+        raise ValueError("Simulation command and arguments is mandatory")
 
     if capture_output:
         pop = subprocess.Popen(

--- a/python/verisocks/verisocks.py
+++ b/python/verisocks/verisocks.py
@@ -87,8 +87,8 @@ class Verisocks:
             delay (float): Delay to be applied prior each connection trial
 
         Raises:
-            ConnectionError if all the successive connection trials are
-            unsucessful
+            ConnectionError: All the successive connection trials have been
+                unsucessful
         """
         if not self._connected:
             logging.info(f"Attempting connection to {self.address}")
@@ -116,8 +116,8 @@ class Verisocks:
             base value as defined within the class constructor applies.
 
         Raises:
-            ConnectionError if no data is received (most likely the socket is
-            closed).
+            ConnectionError: no data is received (most likely the socket is
+                closed).
         """
         if timeout:
             self.sock.settimeout(timeout)
@@ -136,8 +136,8 @@ class Verisocks:
             num_bytes (int): Number of bytes to send
 
         Raises:
-            ConnectionError if no data is written (most likely the socket is
-            closed).
+            ConnectionError: no data is written (most likely the socket is
+                closed).
         """
         sent = 0
         trials = 0


### PR DESCRIPTION
* [Python] Modified `Verisocks` constructor and `Verisocks.connect()` method to include arguments for multiple, delayed connection trials. Examples and test have been simplified accordingly.
* [C] Added correct management of system call interrupts while waiting on client connection in the server code (see [here](https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html) for details about the issue).
* [Doc] Added section on alternative simulators support in doc.
* [Python] Added method `verisocks.utils.setup_sim_run()` to simplify foreseen support for alternative simulators.